### PR TITLE
Fix log sanitisation and switch to script.module.bossanova808 logging

### DIFF
--- a/.github/workflows/addon-checker.yml
+++ b/.github/workflows/addon-checker.yml
@@ -8,10 +8,10 @@ jobs:
     name: Kodi addon checker
     steps:
     - name: Checkout
-      uses: actions/checkout@v4  # Updated from v1
+      uses: actions/checkout@v4
     - name: Kodi addon checker validation
       id: kodi-addon-checker
-      uses: xbmc/action-kodi-addon-checker@v1.3  # Updated from v1.1
+      uses: xbmc/action-kodi-addon-checker@v1.2 
       with:
         kodi-version: matrix
         is-pr: false

--- a/.github/workflows/addon-checker.yml
+++ b/.github/workflows/addon-checker.yml
@@ -8,11 +8,12 @@ jobs:
     name: Kodi addon checker
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4  # Updated from v1
     - name: Kodi addon checker validation
       id: kodi-addon-checker
-      uses: xbmc/action-kodi-addon-checker@v1.1
+      uses: xbmc/action-kodi-addon-checker@v1.3  # Updated from v1.1
       with:
         kodi-version: matrix
         is-pr: false
         addon-id: ${{ github.event.repository.name }}
+        

--- a/.github/workflows/addon-checker.yml
+++ b/.github/workflows/addon-checker.yml
@@ -8,10 +8,10 @@ jobs:
     name: Kodi addon checker
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Kodi addon checker validation
       id: kodi-addon-checker
-      uses: xbmc/action-kodi-addon-checker@v1.1
+      uses: xbmc/action-kodi-addon-checker@v1.2
       with:
         kodi-version: matrix
         is-pr: false

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -27,32 +27,36 @@ msgstr ""
 
 msgctxt "#32024"
 msgid "Android crashlogs are not supported, sorry"
-msgstr "
+msgstr ""
 
 msgctxt "#32025"
 msgid "No log files found to copy ?!"
-msgstr "
+msgstr ""
 
 msgctxt "#32026"
 msgid "Error copying logs"
-msgstr "
+msgstr ""
 
 msgctxt "#32027"
 msgid "No destination path set in the addon settings!"
-msgstr "
+msgstr ""
 
 msgctxt "#32028"
 msgid "Log files copied"
-msgstr "
+msgstr ""
 
 msgctxt "#32029"
 msgid "Something went wrong, (ironically) check your logs!"
-msgstr "
+msgstr ""
 
 msgctxt "#32030"
 msgid "Working..."
-msgstr "
+msgstr ""
 
 msgctxt "#32031"
-msgid "Error making directory to copy log files to"
-msgstr "
+msgid "Error making directory to copy log files to!"
+msgstr ""
+
+msgctxt "#32032"
+msgid "Maximum days age of crashlogs to consider for copy"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -58,5 +58,5 @@ msgid "Error making directory to copy log files to!"
 msgstr ""
 
 msgctxt "#32032"
-msgid "Maximum days age of crashlogs to consider for copy"
+msgid "Max age of crashlogs to copy (days)"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -52,3 +52,7 @@ msgstr "
 msgctxt "#32030"
 msgid "Working..."
 msgstr "
+
+msgctxt "#32031"
+msgid "Error making directory to copy log files to"
+msgstr "

--- a/resources/lib/cabertoss.py
+++ b/resources/lib/cabertoss.py
@@ -90,10 +90,19 @@ def gather_log_files():
 
 def copy_log_files(log_files: List) -> bool:
     """
-    Actually copy the log files to the path in the addon settings
+    Copy the provided Kodi log files into a timestamped destination folder under the configured addon destination.
 
-    @param log_files: List list of log files to copy
-    @return bool: indicating success or failure
+    Detailed behavior:
+    - Expects log_files as a list of 2-element entries [type, path], where `type` is e.g. 'log', 'oldlog', or 'crashlog' and `path` is the source filesystem path.
+    - Creates a destination directory at Store.destination_path named "<hostname>_Kodi_Logs_<YYYY-MM-DD_HH-MM-SS>".
+    - For entries with type 'log' or 'oldlog', reads the source, sanitizes the content with clean_log() (because these paths may be URLs with embedded user/password details), and writes the sanitized content to a file with the same basename in the destination folder.
+    - For other types (e.g., crash logs), copies the source file to the destination folder unchanged.
+
+    Parameters:
+        log_files (List): list of log descriptors [type, path] to copy.
+
+    Returns:
+        bool: True if files were successfully copied, False otherwise.
     """
     if not log_files:
         Logger.error(LANGUAGE(32025))
@@ -128,6 +137,17 @@ def copy_log_files(log_files: List) -> bool:
 
 # This is 'main'...
 def run():
+    """
+    Run the log collection and copying flow: initialize this addon's logging, load configuration, gather Kodi log files, copy them to the configured destination, notify the user, and stop this addon's logging.
+
+    This function performs the module's main orchestration. It:
+    - Starts the logger for this addon's internal logging (not Kodi's general logging system) and loads addon configuration from settings.
+    - If no destination path is configured, shows an error notification and skips copying.
+    - Otherwise, notifies the user, gathers available log files, attempts to copy them to the configured destination, and notifies success (including number of files copied) or failure.
+    - Stops this addon's internal logging before returning.
+
+    Side effects: starts/stops this addon's internal logging, reads configuration, performs filesystem operations (reading, sanitizing, and copying log files), and shows user notifications. Returns None.
+    """
     Logger.start()
     Store.load_config_from_settings()
 

--- a/resources/lib/cabertoss.py
+++ b/resources/lib/cabertoss.py
@@ -20,7 +20,7 @@ def _vfs_join(base: str, name: str) -> str:
     return os.path.join(base, name)
 
 
-def gather_log_files():
+def gather_log_files() -> List[Tuple[str, str]]:
     """
     Gather a list of the standard Kodi log files (Kodi.log, Kodi.old.log) and the latest crash log, if there is one.
 
@@ -29,7 +29,7 @@ def gather_log_files():
 
     # Basic log files
     log_files = [('log', os.path.join(LOG_PATH, 'kodi.log'))]
-    if os.path.exists(os.path.join(LOG_PATH, 'kodi.old.log')):
+    if xbmcvfs.exists(os.path.join(LOG_PATH, 'kodi.old.log')):
         log_files.append(('oldlog', os.path.join(LOG_PATH, 'kodi.old.log')))
 
     # Can we find a crashlog?

--- a/resources/lib/cabertoss.py
+++ b/resources/lib/cabertoss.py
@@ -24,7 +24,7 @@ def gather_log_files():
     """
     Gather a list of the standard Kodi log files (Kodi.log, Kodi.old.log) and the latest crash log, if there is one.
 
-    @return: list of log files in form [type, path], where type is log, oldlog, or crashlog
+    @return: list of log files as (type, path) tuples, where type is 'log', 'oldlog', or 'crashlog'
     """
 
     # Basic log files
@@ -68,11 +68,10 @@ def gather_log_files():
         for item in possible_crashlog_files:
             item_with_path = os.path.join(crashlog_path, item)
             if filematch in item and os.path.isfile(item_with_path):
-                if filematch in item:
-                    # Don't bother with older crashlogs
-                    three_days_ago = datetime.now() - timedelta(days=3)
-                    if three_days_ago < datetime.fromtimestamp(os.path.getmtime(item_with_path)):
-                        items.append(os.path.join(crashlog_path, item))
+                # Don't bother with older crashlogs
+                three_days_ago = datetime.now() - timedelta(days=3)
+                if three_days_ago < datetime.fromtimestamp(os.path.getmtime(item_with_path)):
+                    items.append(os.path.join(crashlog_path, item))
 
         items.sort(key=lambda f:os.path.getmtime(f))
         # Windows crashlogs are a dmp and stacktrace combo...
@@ -97,9 +96,9 @@ def copy_log_files(log_files: List[Tuple[str, str]]) -> bool:
     Copy the provided Kodi log files into a timestamped destination folder under the configured addon destination.
 
     Detailed behavior:
-    - Expects log_files as a list of 2-element entries [type, path], where `type` is e.g. 'log', 'oldlog', or 'crashlog' and `path` is the source filesystem path.
+    - Expects log_files as List[Tuple[str, str]] where `type` is e.g. 'log', 'oldlog', or 'crashlog' and `path` is the source filesystem path.
     - Creates a destination directory at Store.destination_path named "<hostname>_Kodi_Logs_<YYYY-MM-DD_HH-MM-SS>".
-    - For entries with type 'log' or 'oldlog', reads the source, sanitizes the content with clean_log() (because these paths may be URLs with embedded user/password details), and writes the sanitized content to a file with the same basename in the destination folder.
+    - For entries with type 'log' or 'oldlog', reads the source, sanitises the content with clean_log() (because the log content may contain URLs with embedded user/password details), and writes the sanitised content to a file with the same basename in the destination folder.
     - For other types (e.g., crash logs), copies the source file to the destination folder unchanged.
 
     Parameters:
@@ -114,7 +113,7 @@ def copy_log_files(log_files: List[Tuple[str, str]]) -> bool:
         return False
 
     now_folder_name = f"{socket.gethostname()}_Kodi_Logs_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
-    now_destination_path = os.path.join(Store.destination_path, now_folder_name)
+    now_destination_path = _vfs_join(Store.destination_path, now_folder_name)
 
     try:
         Logger.info(f'Making destination folder: {now_destination_path}')

--- a/resources/lib/cabertoss.py
+++ b/resources/lib/cabertoss.py
@@ -69,8 +69,8 @@ def gather_log_files():
             item_with_path = os.path.join(crashlog_path, item)
             if filematch in item and os.path.isfile(item_with_path):
                 # Don't bother with older crashlogs
-                three_days_ago = datetime.now() - timedelta(days=3)
-                if three_days_ago < datetime.fromtimestamp(os.path.getmtime(item_with_path)):
+                x_days_ago = datetime.now() - timedelta(days=Store.crashlog_max_days)
+                if x_days_ago < datetime.fromtimestamp(os.path.getmtime(item_with_path)):
                     items.append(os.path.join(crashlog_path, item))
 
         items.sort(key=lambda f:os.path.getmtime(f))

--- a/resources/lib/cabertoss.py
+++ b/resources/lib/cabertoss.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from time import sleep
 from datetime import datetime, timedelta
 import socket
+from typing import List
 
 import xbmc
 import xbmcvfs
@@ -59,7 +60,6 @@ def gather_log_files():
         filematch = 'kodi_crashlog_'
 
     if crashlog_path and os.path.isdir(crashlog_path):
-        lastcrash = None
         dirs, possible_crashlog_files = xbmcvfs.listdir(crashlog_path)
         for item in possible_crashlog_files:
             item_with_path = os.path.join(crashlog_path, item)
@@ -88,17 +88,17 @@ def gather_log_files():
     return log_files
 
 
-def copy_log_files(log_files: []):
+def copy_log_files(log_files: List) -> bool:
     """
     Actually copy the log files to the path in the addon settings
 
-    @param log_files: [] list of log files to copy
-    @return: None
+    @param log_files: List list of log files to copy
+    @return bool: indicating success or failure
     """
     if not log_files:
         Logger.error(LANGUAGE(32025))
         Notify.error(LANGUAGE(32025))
-        return
+        return False
 
     now_folder_name = f"{socket.gethostname()}_Kodi_Logs_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
     now_destination_path = os.path.join(Store.destination_path, now_folder_name)
@@ -128,7 +128,7 @@ def copy_log_files(log_files: []):
 
 # This is 'main'...
 def run():
-    footprints()
+    Logger.start()
     Store.load_config_from_settings()
 
     if not Store.destination_path:
@@ -142,4 +142,4 @@ def run():
         else:
             Notify.info(LANGUAGE(32029))
     # and, we're done...
-    footprints(startup=False)
+    Logger.stop()

--- a/resources/lib/clean.py
+++ b/resources/lib/clean.py
@@ -11,6 +11,8 @@ def clean_log(content: str) -> str:
     replaces = (
         # Replace only the credentials part between '//' and '@'
         (r'(?<=//)([^/@:\s]+):([^/@\s]+)@', r'USER:PASSWORD@'),
+        # Also scrub username only (no password)
+        (r'(?<=//)([^/@:\s]+)@', r'USER@'),
         # Replace XML username/password; keep it local to the tag
         (r'(?is)<user>[^<]*</user>', r'<user>USER</user>'),
         (r'(?is)<pass>[^<]*</pass>', r'<pass>PASSWORD</pass>'),

--- a/resources/lib/clean.py
+++ b/resources/lib/clean.py
@@ -1,14 +1,20 @@
 import re
 
 
-def clean_log(content):
+def clean_log(content: str) -> str:
     """
     Remove username/password details from log file content
 
     @param content:
     @return:
     """
-    replaces = (('//.+?:.+?@', '//USER:PASSWORD@'), ('<user>.+?</user>', '<user>USER</user>'), ('<pass>.+?</pass>', '<pass>PASSWORD</pass>'),)
+    replaces = (
+        # Replace only the credentials part between '//' and '@'
+        (r'(?<=//)([^/@:\s]+):([^/@\s]+)@', r'USER:PASSWORD@'),
+        # Replace XML username/password; keep it local to the tag
+        (r'(?is)<user>[^<]*</user>', r'<user>USER</user>'),
+        (r'(?is)<pass>[^<]*</pass>', r'<pass>PASSWORD</pass>'),
+    )
 
     for pattern, repl in replaces:
         content = re.sub(pattern, repl, content)

--- a/resources/lib/clean.py
+++ b/resources/lib/clean.py
@@ -11,5 +11,5 @@ def clean_log(content):
     replaces = (('//.+?:.+?@', '//USER:PASSWORD@'), ('<user>.+?</user>', '<user>USER</user>'), ('<pass>.+?</pass>', '<pass>PASSWORD</pass>'),)
 
     for pattern, repl in replaces:
-        sanitised = re.sub(pattern, repl, content)
-        return sanitised
+        content = re.sub(pattern, repl, content)
+    return content

--- a/resources/lib/store.py
+++ b/resources/lib/store.py
@@ -13,8 +13,8 @@ class Store:
 
     # Static class variables, referred to elsewhere by Store.whatever
     # https://docs.python.org/3/faq/programming.html#how-do-i-create-static-class-data-and-static-class-methods
-    destination_path = None
-    crashlog_max_days = 3
+    destination_path: str = ''
+    crashlog_max_days: int = 3
 
     def __init__(self):
         """
@@ -35,5 +35,5 @@ class Store:
             Logger.info(f'Logs will be tossed to: {clean_log(Store.destination_path)}')
         else:
             Logger.warning('No path set to toss logs to.')
-        Store.crashlog_max_days = ADDON.getSetting('crashlog_max_days') or 3
+        Store.crashlog_max_days = int(ADDON.getSetting('crashlog_max_days')) or 3
         Logger.info(f'Crashlog max days: {Store.crashlog_max_days}')

--- a/resources/lib/store.py
+++ b/resources/lib/store.py
@@ -29,6 +29,8 @@ class Store:
         Reads the 'log_path' setting and assigns it to Store.destination_path, then logs the resolved path (sanitized with clean_log because these paths may be URLs with embedded user/password details). This is called at startup and when settings are reloaded; it has no return value.
         """
         Logger.info("Loading configuration from settings")
-        Store.destination_path = ADDON.getSetting('log_path')
-
-        Logger.info(f'Logs will be tossed to: {clean_log(Store.destination_path)}')
+        Store.destination_path = ADDON.get_setting('log_path')
+        if Store.destination_path:
+            Logger.info(f'Logs will be tossed to: {clean_log(Store.destination_path)}')
+        else:
+            Logger.warning(f'No path set to toss logs to.')

--- a/resources/lib/store.py
+++ b/resources/lib/store.py
@@ -33,4 +33,4 @@ class Store:
         if Store.destination_path:
             Logger.info(f'Logs will be tossed to: {clean_log(Store.destination_path)}')
         else:
-            Logger.warning(f'No path set to toss logs to.')
+            Logger.warning('No path set to toss logs to.')

--- a/resources/lib/store.py
+++ b/resources/lib/store.py
@@ -14,6 +14,7 @@ class Store:
     # Static class variables, referred to elsewhere by Store.whatever
     # https://docs.python.org/3/faq/programming.html#how-do-i-create-static-class-data-and-static-class-methods
     destination_path = None
+    crashlog_max_days = 3
 
     def __init__(self):
         """
@@ -29,8 +30,10 @@ class Store:
         Reads the 'log_path' setting and assigns it to Store.destination_path, then logs the resolved path (sanitized with clean_log because these paths may be URLs with embedded user/password details). This is called at startup and when settings are reloaded; it has no return value.
         """
         Logger.info("Loading configuration from settings")
-        Store.destination_path = ADDON.get_setting('log_path')
+        Store.destination_path = ADDON.getSetting('log_path') or ''
         if Store.destination_path:
             Logger.info(f'Logs will be tossed to: {clean_log(Store.destination_path)}')
         else:
             Logger.warning('No path set to toss logs to.')
+        Store.crashlog_max_days = ADDON.getSetting('crashlog_max_days') or 3
+        Logger.info(f'Crashlog max days: {Store.crashlog_max_days}')

--- a/resources/lib/store.py
+++ b/resources/lib/store.py
@@ -31,8 +31,3 @@ class Store:
         Store.destination_path = ADDON.getSetting('log_path')
 
         Logger.info(f'Logs will be tossed to: {clean_log(Store.destination_path)}')
-
-
-
-
-

--- a/resources/lib/store.py
+++ b/resources/lib/store.py
@@ -1,6 +1,6 @@
-from bossanova808.constants import *
+from bossanova808.constants import ADDON
 from bossanova808.logger import Logger
-from resources.lib.clean import *
+from resources.lib.clean import clean_log
 
 
 class Store:

--- a/resources/lib/store.py
+++ b/resources/lib/store.py
@@ -24,8 +24,9 @@ class Store:
     @staticmethod
     def load_config_from_settings():
         """
-        Load in the addon settings, at start or reload them if they have been changed
-        Log each setting as it is loaded
+        Load the addon's configuration from persistent settings.
+
+        Reads the 'log_path' setting and assigns it to Store.destination_path, then logs the resolved path (sanitized with clean_log because these paths may be URLs with embedded user/password details). This is called at startup and when settings are reloaded; it has no return value.
         """
         Logger.info("Loading configuration from settings")
         Store.destination_path = ADDON.getSetting('log_path')

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -17,6 +17,13 @@
                         <heading>32001</heading>
                     </control>
                 </setting>
+                <setting id="crashlog_max_days" type="integer" label="32005" help="">
+                    <level>0</level>
+                    <default>3</default>
+                    <control type="edit" format="integer">
+                        <heading>32005</heading>
+                    </control>
+                </setting>
             </group>
         </category>
     </section>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -20,6 +20,11 @@
                 <setting id="crashlog_max_days" type="integer" label="32032" help="">
                     <level>0</level>
                     <default>3</default>
+                    <constraints>
+                        <minimum>0</minimum>
+                        <maximum>365</maximum>
+                        <step>1</step>
+                    </constraints>
                     <control type="edit" format="integer">
                         <heading>32032</heading>
                     </control>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -17,11 +17,11 @@
                         <heading>32001</heading>
                     </control>
                 </setting>
-                <setting id="crashlog_max_days" type="integer" label="32005" help="">
+                <setting id="crashlog_max_days" type="integer" label="32032" help="">
                     <level>0</level>
                     <default>3</default>
                     <control type="edit" format="integer">
-                        <heading>32005</heading>
+                        <heading>32032</heading>
                     </control>
                 </setting>
             </group>


### PR DESCRIPTION
Fix error in clean logs
Use new script.module.bossanov808 logging functions 
Minor formatting changes per PyCharm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds configurable crashlog age limit (setting + localisation) and discovers crashlogs for copying.

* **Bug Fixes**
  * Improved log sanitisation with multiple replacement patterns and consistent returns.
  * More robust log copying: validates inputs, creates destination folders, handles different log types, and reports outcomes including type/basename.

* **Refactor**
  * Unified lifecycle orchestration with clearer start/stop flow.

* **Chores**
  * CI workflow updates and typing/import tidies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->